### PR TITLE
Works with firmata 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "buffer": "^4.6.0",
-    "firmata": "^0.11.3",
+    "firmata": "^0.16.0",
     "lodash.debounce": "^4.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "buffer": "^4.6.0",
-    "firmata": "^0.16.0",
+    "firmata": ">=0.11.3 <1.0",
     "lodash.debounce": "^4.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Loosen up the dependency on firmata-js, which is up to 0.16.0.  The `johnny-five` package, which this is more-or-less a plugin for, uses `latest` firmata, but due to the more restrictive dependency here two copies of firmata were getting installed when using them together.  Now they can use the same copy.