### PR TITLE
Update to 0.6.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ var CAP_THRESHOLD = 300;  // Threshold for considering a cap touch input pressed
 function Playground(options) {
   var port = options.port;
   delete options.port;
-  Firmata.call(this, port, options);
+  Firmata.Board.call(this, port, options);
 
   // Used to provide private state to this instance
   var state = {
@@ -74,7 +74,9 @@ function Playground(options) {
   }
 }
 
-Playground.prototype = Object.create(Firmata.prototype, {
+Playground.hasRegisteredSysexResponse = false;
+
+Playground.prototype = Object.create(Firmata.Board.prototype, {
   constructor: {
     value: Playground
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playground-io",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Adafruit Circuit Playground IO Plugin",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Rick accepted a couple of our pull requests upstream ([4](https://github.com/rwaldron/playground-io/pull/4) and [5](https://github.com/rwaldron/playground-io/pull/5)) and released a new version with additional tests. This brings our fork up-to-date from [v0.5.0](https://github.com/rwaldron/playground-io/releases/tag/v0.5.0) to [v0.6.0](https://github.com/rwaldron/playground-io/releases/tag/v0.6.0) ([diff](https://github.com/rwaldron/playground-io/compare/v0.5.0...v0.6.0)).  I'll release v0.6.0-cdo.0 after merging this PR.

At this point we might be functionally in sync with upstream and not really need a fork - I just tested v0.6.0 in Maker Toolkit and it seems to work great.  So we'll get the fork in sync, and maybe end up depending directly on rwaldron/playground-io#v0.6.0 anyway - but merging this now will make customizing easier down the road if it's necessary.